### PR TITLE
Promise support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 sudo: false
 language: node_js
 node_js:
-- '0.8'
-- '0.10'
 - '0.12'
 - '4'
 - '6'

--- a/README.md
+++ b/README.md
@@ -70,56 +70,39 @@ Execute a function ambidextrously (normalizes the differences between synchronou
 ``` javascript
 // Import
 const ambi = require('ambi')
-let result = null
 
 // Sample methods
 function syncMethod (x, y) {
     return x * y
 }
-
 function promiseMethod (x, y) {
     return Promise.resolve(x * y)
 }
 function asyncMethod (x, y, next) {
-    return setTimeout(function () {
+    setTimeout(function () {
         next(null, x * y)
     }, 0)
 }
 
 // Call the synchronous function asynchronously
 // ambi adds support for this asynchronous callback automatically
-result = ambi(syncMethod, 5, 2, function (err, result) {
+ambi(syncMethod, 5, 2, function (err, result) {
     console.log(err, result)  // null, 10
 })
-console.log(result)  // Null, result is returned via callback
 
 // Call the promise returning function asynchronously
 // ambi adds support for this asynchrounous callback automatically
-result = ambi(promiseMethod, 5, 2, function (err, result) {
-    console.log(err, result) // null 10
+ambi(promiseMethod, 5, 2, function (err, result) {
+    console.log(err, result) // null, 10
 })
-console.log(result) // null - result is returned via callback
 
 // Call the asynchronous function asynchronously
 // ambi doesn't do anything special here
-result = ambi(asyncMethod, 5, 2, function (err, result) {
+ambi(asyncMethod, 5, 2, function (err, result) {
     console.log(err, result)  // null, 10
 })
-console.log(result)  // null - result is returned via callback
 ```
 
-### Custom promise implementations
-
-By default, Ambi constructs promises when needed using native promises. If
-you wish to use a different promise implementation or lack native promises,
-you can set `ambi.promise` to a function that returns a promise implementation.
-
-```javascript
-const ambi = require('ambi')
-const Bluebird = require('bluebird')
-
-ambi.promise = function () { return Bluebird }
-```
 
 ### Notes
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 
 <!-- DESCRIPTION/ -->
 
-Execute a function ambidextrously (normalizes the differences between synchronous and asynchronous functions). Useful for treating synchronous functions as asynchronous functions (like supporting both synchronous and asynchronous event definitions automatically).
+Execute a function ambidextrously (normalizes the differences between synchronous, promises, and asynchronous functions). Useful for treating synchronous functions as asynchronous functions (like supporting both synchronous and asynchronous event definitions automatically).
 
 <!-- /DESCRIPTION -->
 
@@ -76,6 +76,10 @@ let result = null
 function syncMethod (x, y) {
     return x * y
 }
+
+function promiseMethod (x, y) {
+    return Promise.resolve(x * y)
+}
 function asyncMethod (x, y, next) {
     return setTimeout(function () {
         next(null, x * y)
@@ -87,17 +91,35 @@ function asyncMethod (x, y, next) {
 result = ambi(syncMethod, 5, 2, function (err, result) {
     console.log(err, result)  // null, 10
 })
-console.log(result)  // 10 - just like normal
+console.log(result)  // Null, result is returned via callback
+
+// Call the promise returning function asynchronously
+// ambi adds support for this asynchrounous callback automatically
+result = ambi(promiseMethod, 5, 2, function (err, result) {
+    console.log(err, result) // null 10
+})
+console.log(result) // null - result is returned via callback
 
 // Call the asynchronous function asynchronously
 // ambi doesn't do anything special here
 result = ambi(asyncMethod, 5, 2, function (err, result) {
     console.log(err, result)  // null, 10
 })
-console.log(result)  // setTimeout - just like normal
+console.log(result)  // null - result is returned via callback
 ```
 
+### Custom promise implementations
 
+By default, Ambi constructs promises when needed using native promises. If
+you wish to use a different promise implementation or lack native promises,
+you can set `ambi.promise` to a function that returns a promise implementation.
+
+```javascript
+const ambi = require('ambi')
+const Bluebird = require('bluebird')
+
+ambi.promise = function () { return Bluebird }
+```
 
 ### Notes
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ambi",
-  "version": "3.2.0",
-  "description": "Execute a function ambidextrously (normalizes the differences between synchronous and asynchronous functions). Useful for treating synchronous functions as asynchronous functions (like supporting both synchronous and asynchronous event definitions automatically).",
+  "version": "4.0.0",
+  "description": "Execute a function ambidextrously (normalizes the differences between synchronous, promise based, and asynchronous functions). Useful for treating synchronous functions as asynchronous functions (like supporting both synchronous and asynchronous event definitions automatically).",
   "homepage": "https://github.com/bevry/ambi",
   "license": "MIT",
   "keywords": [
@@ -49,7 +49,8 @@
   ],
   "contributors": [
     "Benjamin Lupton <b@lupton.cc> (http://balupton.com)",
-    "Sean Fridman <mail@seanfridman.com> (http://seanfridman.com)"
+    "Sean Fridman <mail@seanfridman.com> (http://seanfridman.com)",
+    "Chris Tavares <cct@tavaresstudios.com>"
   ],
   "bugs": {
     "url": "https://github.com/bevry/ambi/issues"
@@ -98,7 +99,7 @@
         "require"
       ],
       "engines": {
-        "node": "0.8 || 0.10 || 0.12 || 4 || 6 || 8 || 10 || 11",
+        "node": "0.12 || 4 || 6 || 8 || 10 || 11",
         "browsers": false
       }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ambi",
-  "version": "4.0.0",
+  "version": "3.2.0",
   "description": "Execute a function ambidextrously (normalizes the differences between synchronous, promise based, and asynchronous functions). Useful for treating synchronous functions as asynchronous functions (like supporting both synchronous and asynchronous event definitions automatically).",
   "homepage": "https://github.com/bevry/ambi",
   "license": "MIT",

--- a/source/index.js
+++ b/source/index.js
@@ -4,7 +4,7 @@
 const typeChecker = require('typechecker')
 
 // Define
-function ambi(method, ...args) {
+module.exports = function ambi(method, ...args) {
 	// Extract the preceeding arguments and the completion callback
 	const simpleArguments = args.slice(0, -1)
 	const completionCallback = args.slice(-1)[0]
@@ -89,7 +89,7 @@ function ambi(method, ...args) {
 
 		// Wrap result in a promise. Sync results will be turned into promise,
 		// returned promises will be returned directly.
-		ambi.promise().resolve(result).then(
+		Promise.resolve(result).then(
 			function onSuccess(value) {
 				// Check if error was returned rather than thrown
 				if (typeChecker.isError(value)) {
@@ -112,15 +112,3 @@ function ambi(method, ...args) {
 	// so returning anything would be inconsistent
 	return null
 }
-
-// Hook for providing custom Promise implementation. Defaults to native promise
-// if available, but can set it to something else if needed or desired.
-ambi.promise = Promise
-	? function() { return Promise }
-	: function() {
-		throw new Error(
-			'No native promise implementation found, set ambi.promise to your choice of promise implementation'
-		)
-	}
-
-module.exports = ambi

--- a/source/index.js
+++ b/source/index.js
@@ -4,7 +4,7 @@
 const typeChecker = require('typechecker')
 
 // Define
-module.exports = function ambi(method, ...args) {
+function ambi(method, ...args) {
 	// Extract the preceeding arguments and the completion callback
 	const simpleArguments = args.slice(0, -1)
 	const completionCallback = args.slice(-1)[0]
@@ -89,7 +89,7 @@ module.exports = function ambi(method, ...args) {
 
 		// Wrap result in a promise. Sync results will be turned into promise,
 		// returned promises will be returned directly.
-		Promise.resolve(result).then(
+		ambi.promise().resolve(result).then(
 			function onSuccess(value) {
 				// Check if error was returned rather than thrown
 				if (typeChecker.isError(value)) {
@@ -112,3 +112,15 @@ module.exports = function ambi(method, ...args) {
 	// so returning anything would be inconsistent
 	return null
 }
+
+// Hook for providing custom Promise implementation. Defaults to native promise
+// if available, but can set it to something else if needed or desired.
+ambi.promise = Promise
+	? function() { return Promise }
+	: function() {
+		throw new Error(
+			'No native promise implementation found, set ambi.promise to your choice of promise implementation'
+		)
+	}
+
+module.exports = ambi

--- a/source/test.js
+++ b/source/test.js
@@ -507,4 +507,22 @@ kava.describe('ambi', function(describe, it) {
 			done()
 		})
 	})
+
+	it('should call ambi.promise to construct promises', function(done) {
+		let ambiPromiseCalled = false
+		ambi.promise = function() {
+			ambiPromiseCalled = true
+			return Promise
+		}
+
+		function successfulPromiseReturning() {
+			return Promise.resolve('async')
+		}
+
+		ambi(successfulPromiseReturning, function(err, result) {
+			equal(null, err, 'Should not return error')
+			equal(ambiPromiseCalled, true, 'Should have called ambi.Promise')
+			done()
+		})
+	})
 })

--- a/source/test.js
+++ b/source/test.js
@@ -507,22 +507,4 @@ kava.describe('ambi', function(describe, it) {
 			done()
 		})
 	})
-
-	it('should call ambi.promise to construct promises', function(done) {
-		let ambiPromiseCalled = false
-		ambi.promise = function() {
-			ambiPromiseCalled = true
-			return Promise
-		}
-
-		function successfulPromiseReturning() {
-			return Promise.resolve('async')
-		}
-
-		ambi(successfulPromiseReturning, function(err, result) {
-			equal(null, err, 'Should not return error')
-			equal(ambiPromiseCalled, true, 'Should have called ambi.Promise')
-			done()
-		})
-	})
 })


### PR DESCRIPTION
Implements #2. 

Added transparent support for promise returning functions.
Added `ambi.promise` as a hook so that the promise implementation used can be replaced if desired.
Updated docs.

Hopefully I didn't break the automation; I'm working on Windows and a bunch of the NPM scripts don't work there, and I felt that fixing that problem (if you want to) is better in a separate PR.
